### PR TITLE
Fix word being cut in the CLI when they reach the console max width

### DIFF
--- a/workshop-cli/WorkshopCli/TypewriterEffect.cs
+++ b/workshop-cli/WorkshopCli/TypewriterEffect.cs
@@ -17,10 +17,22 @@ namespace workshopCli
             Console.ForegroundColor = color;
 
             string[] words = text.Split(' ');
+            int consoleWidth = Console.WindowWidth;
+            int currentLineLength = 0;
 
             foreach (string word in words)
             {
+                // Check if the word will exceed the console width
+                if (currentLineLength + word.Length + 1 > consoleWidth)
+                {
+                    // Move to the next line if thats the case
+                    Console.WriteLine();
+                    currentLineLength = 0;
+                }
+
+                // Print the word that was cut
                 Console.Write(word + " ");
+                currentLineLength += word.Length + 1; 
                 Thread.Sleep(delay);
             }
 


### PR DESCRIPTION
Fixed words being cut in the CLI when they reach the console max width.
Tested it on two different PC to check if it works.