### PR TITLE
Remove unecessary console logs to prevent having empty spaces

### DIFF
--- a/workshop-cli/WorkshopCli/GitHubManager.cs
+++ b/workshop-cli/WorkshopCli/GitHubManager.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using System.IO.Compression;
+using System.IO;
 
 namespace workshopCli;
 
@@ -7,7 +7,6 @@ public class GitHubManager
 {
     public void CreateBranch()
     {
-        
         var pythonScriptPath = $"{GuideCli.ResourcesPath}/github_branch.py"; // Replace with the actual path to your Python script
         
         var processStartInfo = new ProcessStartInfo
@@ -33,74 +32,66 @@ public class GitHubManager
     }
 
     public void Commit(string name)
+    {
+        var username = name;
+
+        if (username != null)
         {
-            //Console.WriteLine("commit");
-            var username = name;
-            
-            if (username != null)
+            username = username.Replace(" ", "-");
+        }
+        var desktopPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), "repoWorkshop");
+
+        var sourceFolderPath = Path.Combine(desktopPath, $"{username}_{DateTime.Now:dd-MM-yyyy}");
+
+        var folderPath = Path.Combine(GuideCli.ResourcesPath, "Workshop2023");
+
+        var files = Directory.GetFiles(sourceFolderPath, "*", SearchOption.AllDirectories);
+
+        foreach (var file in files)
+        {
+            var relativePath = file.Replace(sourceFolderPath, "").TrimStart(Path.DirectorySeparatorChar);
+            var destPath = Path.Combine(folderPath, relativePath);
+            var destDir = Path.GetDirectoryName(destPath);
+
+            if (!Directory.Exists(destDir))
             {
-                username = username.Replace(" ", "-");
-                //Console.WriteLine(username);
-            }
-            var desktopPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), "repoWorkshop");
-
-            var sourceFolderPath = Path.Combine(desktopPath, $"{username}_{DateTime.Now.ToString("dd-MM-yyyy")}");
-            
-            var folderPath = Path.Combine(GuideCli.ResourcesPath, "Workshop2023");
-
-            var files = Directory.GetFiles(sourceFolderPath, "*", SearchOption.AllDirectories);
-
-            foreach (var file in files)
-            {
-                var relativePath = file.Replace(sourceFolderPath, "").TrimStart(Path.DirectorySeparatorChar);
-                var destPath = Path.Combine(folderPath, relativePath);
-                var destDir = Path.GetDirectoryName(destPath);
-
-                if (!Directory.Exists(destDir))
-                {
-                    Directory.CreateDirectory(destDir);
-                    //Console.WriteLine($"Created folder: {destDir}");
-                }
-
-                File.Copy(file, destPath, true);
-                //Console.WriteLine($"Copied file: {relativePath}");
+                Directory.CreateDirectory(destDir);
             }
 
-            var pythonScriptPath = $"{GuideCli.ResourcesPath}/github_commit.py";
-
-            var processStartInfo = new ProcessStartInfo
-            {
-                FileName = "python",
-                Arguments = pythonScriptPath,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            try
-            {
-                var process = new Process { StartInfo = processStartInfo };
-
-                // Configure asynchronous event handlers for output and error data received
-                process.OutputDataReceived += (sender, e) => Console.WriteLine();
-                process.ErrorDataReceived += (sender, e) => Console.WriteLine();
-
-                // Start the process
-                process.Start();
-
-                // Begin asynchronous read operations for output and error streams
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-
-                // Wait for the process to exit
-                process.WaitForExit();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error executing Python script: {ex.Message}");
-            }
+            File.Copy(file, destPath, true);
         }
 
-   
+        var pythonScriptPath = $"{GuideCli.ResourcesPath}/github_commit.py";
+
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = "python",
+            Arguments = pythonScriptPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        Process process = null;
+        try
+        {
+            process = new Process { StartInfo = processStartInfo };
+
+            // Start the process
+            process.Start();
+
+            // Begin asynchronous read operations for output and error streams
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            // Wait for the process to exit
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error executing Python script: {ex.Message}");
+        }
+        
+    }
 }


### PR DESCRIPTION
Remove unecessary console logs to prevent having empty spaces. It usually showed in the console that the files were being commited. Not necessary